### PR TITLE
'Fixed' an error, where PoB has an Enchantment listed as skill, so the import would not work.

### DIFF
--- a/src/poe/level/fx/BuildsPanel_Controller.java
+++ b/src/poe/level/fx/BuildsPanel_Controller.java
@@ -543,6 +543,10 @@ public class BuildsPanel_Controller implements Initializable {
             SocketGroup sg = new SocketGroup();
             for( String gemString : sgList){
                 Gem gem = GemHolder.getInstance().createGemFromCache(gemString,pobBuild.getClassName());
+                if(gem == null) {
+                    System.err.println(gemString);
+                    continue;
+                }
                 if(gem.isActive && sg.getActiveGem() == null){
                     sg.setActiveGem(gem);
                 }


### PR DESCRIPTION
Apparently, when a Enchantment is listed as skill in PoB our import gets a NullPointer on a Gem, because it finds no gem with the name of the enchantment.

Workaround --> Just check if the gem is null, if yes just skip it. 
It's not perfect but for now it works.
Better solution: Have a list of all enchantments and check if it is one of them and List it as such.